### PR TITLE
Fix passing value instead of full header for multipart header part

### DIFF
--- a/lib/Goetas/Mail/ToSwiftMailParser/MimeParser.php
+++ b/lib/Goetas/Mail/ToSwiftMailParser/MimeParser.php
@@ -80,10 +80,11 @@ class MimeParser {
     protected function parseParts($stream, $partHeaders) {
         $parts = array ();
         $part = 0;
-        $contentType = array_key_exists( 'content-type', $partHeaders ) ? $this->extractValueHeader ( $partHeaders ['content-type'] ) : '';
+        $contentTypeHeader = array_key_exists( 'content-type', $partHeaders ) ? $partHeaders ['content-type']  : '';
+        $contentType =  $this->extractValueHeader( $contentTypeHeader );
 
         if (stripos ( $contentType, 'multipart/' ) !== false) {
-            $headerParts = $this->extractHeaderParts ( $contentType );
+            $headerParts = $this->extractHeaderParts ( $contentTypeHeader );
             $boundary = $headerParts ["boundary"];
         } else {
             $boundary = null;


### PR DESCRIPTION
I changed logic accidentally in my last pull request, fixing it now. Sorry
