### PR TITLE
convert headers to proper encoding

### DIFF
--- a/src/Mime/HeaderDecoder.php
+++ b/src/Mime/HeaderDecoder.php
@@ -52,12 +52,12 @@ class HeaderDecoder
                 case 'q':
                     $out .= self::convertCharset(preg_replace_callback('/=([0-9a-f]{2})/i', function ($ord) {
                         return chr(hexdec($ord [1]));
-                    }, str_replace('_', ' ', $encoded_text)), $orig_charset, 'UTF-8');
+                    }, str_replace('_', ' ', $encoded_text)), $orig_charset, mb_internal_encoding());
                     break;
 
                 case 'B':
                 case 'b':
-                    $out .= self::convertCharset(base64_decode($encoded_text), $orig_charset, 'UTF-8');
+                    $out .= self::convertCharset(base64_decode($encoded_text), $orig_charset, mb_internal_encoding());
                     break;
 
                 default:
@@ -73,7 +73,6 @@ class HeaderDecoder
 
     private static function convertCharset(string $str, string $orig, string $to)
     {
-        //@todo convert charset
-        return $str;
+        return mb_convert_encoding($str, $to, $orig);
     }
 }

--- a/tests/BasicTest.php
+++ b/tests/BasicTest.php
@@ -102,5 +102,16 @@ class BasicTest extends \PHPUnit_Framework_TestCase
 
         $this->parser->parseStream($inputStream, true); // now $mail is a \Swift_Message  object
     }
+
+    public function testDifferentHeadersEncoding()
+    {
+        // read a mail message saved into eml format (or similar)
+        $inputStream = fopen(__DIR__ . '/res/test-different-headers-encoding.txt', 'rb');
+
+        $mail = $this->parser->parseStream($inputStream, true); // now $mail is a \Swift_Message  object
+
+        $this->assertEquals(['test@example.com' => 'Táste'], $mail->getTo());
+        $this->assertEquals('Táste', $mail->getSubject());
+    }
 }
 

--- a/tests/res/test-different-headers-encoding.txt
+++ b/tests/res/test-different-headers-encoding.txt
@@ -1,0 +1,9 @@
+From: John Smith <john@example.com>
+MIME-Version: 1.0
+Subject: =?utf-8?Q?T=C3=A1ste?=
+To: =?iso-8859-1?Q?T=E1ste?=
+        <test@example.com>
+Content-Type: text/plain
+content-transfer-encoding: base64
+
+dGhpcyBpcyB0aGUgYm9keSB0ZXh0


### PR DESCRIPTION
because swift message headers looses header charset encoding, special characters are not properly extracted