### PR TITLE
fix header parsing when there is semicolon inside

### DIFF
--- a/src/MimeParser.php
+++ b/src/MimeParser.php
@@ -229,7 +229,20 @@ class MimeParser
             $parts = explode(";", $header);
             array_shift($parts);
             $p = array();
+            $part = '';
             foreach ($parts as $pv) {
+                if (preg_match('/="[^"]+$/', $pv)) {
+                    $part = $pv;
+                    continue;
+                }
+                if ($part !== '') {
+                    $part .= ';' . $pv;
+                    if (preg_match('/="[^"]+$/', $part)) {
+                        continue;
+                    } else {
+                        $pv = $part;
+                    }
+                }
                 if (strpos($pv, '=') === false) {
                     continue;
                 }

--- a/tests/BasicTest.php
+++ b/tests/BasicTest.php
@@ -141,4 +141,15 @@ class BasicTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(['test@example.com' => 'Táste'], $mail->getTo());
         $this->assertEquals('Táste', $mail->getSubject());
     }
+
+    public function testHeaderWithSemicolon()
+    {
+        $inputStream = fopen(__DIR__ . '/res/test-header-with-semicolon.txt', 'rb');
+
+        /** @var \Swift_Message $mail */
+        $mail = $this->parser->parseStream($inputStream, true);
+        $children = $mail->getChildren();
+        $this->assertCount(2, $children);
+        $this->assertEquals('attachment; filename="test;.txt"', $children[1]->getHeaders()->get('content-disposition')->getFieldBody());
+    }
 }

--- a/tests/res/test-header-with-semicolon.txt
+++ b/tests/res/test-header-with-semicolon.txt
@@ -1,0 +1,24 @@
+From: John Smith <john@example.com>
+MIME-Version: 1.0
+Subject: =?UTF-8?B?0J/RgNC+0LLQtdGA0LrQsA==?=
+To: Mark Smith <mark@example.com>
+Bcc: Anna Smith <anna@example.com>
+Cc: Luis Smith <luis@example.com>
+Content-Type: multipart/mixed;
+        boundary="XXXXboundary text"
+
+This is a multipart message in MIME format.
+
+--XXXXboundary text
+Content-Type: text/plain
+
+this is the body text
+
+--XXXXboundary text
+Content-Type: text/plain;
+Content-Disposition: attachment;
+        filename="test;.txt"
+
+this is the attachment text
+
+--XXXXboundary text--


### PR DESCRIPTION
sometimes header would have semicolon inside, and because of that there would be parsing error